### PR TITLE
FT2232H Mini-Module instructions + RPi2 OOCD configuration script

### DIFF
--- a/armjtag/README
+++ b/armjtag/README
@@ -150,16 +150,6 @@ that sells FTDI parts might also sell FTDI boards.
 
 
 
-FT2232H Mini Module:
-
-TODO when I get one, I assume it is very very similar if not the same
-as the FT4232H below, the pinout should be the same I am using the A
-and B sections of the chip so those match, the board pinouts may or
-may not match the FT4232H board.  Not hard to figure out from the
-FTDI documents though.
-
-
-
 FT4232H Mini Module:
 
 Searching for this you get the datasheet for the development board.  You
@@ -290,7 +280,27 @@ show the four uarts (/dev/ttyUSBx) the first one on the list will go
 away when we take it over to do jtag, the second one listed will be
 the one you use for uart/serial communications to the raspberry pi.
 
+FT2232H Mini Module:
 
+The FT2232H Mini Module is very similar to the FT4232H above. The only
+difference relevant in our case is the location of the the UART pins,
+instead giving us the connections:
+
+JTAG: (FT board left, Raspi right)
+  TCK:   CN2-7   P1-22
+  TDI:   CN2-10  P1-7
+  TDO:   CN2-9   P1-18
+  TMS:   CN2-12  P1-13
+UART:
+  TXRX:  CN3-26  P1-10
+  RXTX:  CN3-25  P1-8
+Ground:
+  GND:   CN2-2   P1-6
+Raspi to Raspi:
+  TRST:  P1-1    P1-15
+FTDI board to FTDI board:
+  VCCIO: CN2-1   CN2-11
+  VCC:   CN3-1   CN3-3
 
 
 Other alternatives, it doesnt take too much work to use the ftdi drivers

--- a/armjtag/rpi2/README
+++ b/armjtag/rpi2/README
@@ -215,16 +215,6 @@ that sells FTDI parts might also sell FTDI boards.
 
 
 
-FT2232H Mini Module:
-
-TODO when I get one, I assume it is very very similar if not the same
-as the FT4232H below, the pinout should be the same I am using the A
-and B sections of the chip so those match, the board pinouts may or
-may not match the FT4232H board.  Not hard to figure out from the
-FTDI documents though.
-
-
-
 FT4232H Mini Module:
 
 Searching for this you get the datasheet for the development board.  You
@@ -355,6 +345,29 @@ show the four uarts (/dev/ttyUSBx) the first one on the list will go
 away when we take it over to do jtag, the second one listed will be
 the one you use for uart/serial communications to the raspberry pi.
 
+
+
+FT2232H Mini Module:
+
+The FT2232H Mini Module is very similar to the FT4232H above. The only
+difference relevant in our case is the location of the the UART pins,
+instead giving us the connections:
+
+JTAG: (FT board left, Raspi right)
+  TCK:   CN2-7   P1-22
+  TDI:   CN2-10  P1-7
+  TDO:   CN2-9   P1-18
+  TMS:   CN2-12  P1-13
+UART:
+  TXRX:  CN3-26  P1-10
+  RXTX:  CN3-25  P1-8
+Ground:
+  GND:   CN2-2   P1-6
+Raspi to Raspi:
+  TRST:  P1-1    P1-15
+FTDI board to FTDI board:
+  VCCIO: CN2-1   CN2-11
+  VCC:   CN3-1   CN3-3
 
 
 

--- a/armjtag/rpi2/bcmrpi2.cfg
+++ b/armjtag/rpi2/bcmrpi2.cfg
@@ -1,10 +1,10 @@
-
-
 telnet_port 4444
-#gdb_port 0
-#tcl_port 0
+#TODO: Verify gdb setup works as intended.
+#TODO: With the command "cache_config" we could configure the L2 cache and avoid the problem which occurs if you wait too long to connect via JTAG...
+gdb_port 3333
+#tcl_port 0 #No Tcl port needed...
 
-#jtag_khz 1000
+#jtag_khz 1000 #Not needed?
 adapter_khz 1000
 
 if { [info exists CHIPNAME] } {
@@ -13,35 +13,34 @@ if { [info exists CHIPNAME] } {
 	set  _CHIPNAME bcmrpi2
 }
 
-# Main CPU DAP
 if { [info exists DAP_TAPID] } {
 	set _DAP_TAPID $DAP_TAPID
 } else {
 	set _DAP_TAPID 0x4ba00477
 }
 
-jtag newtap $_CHIPNAME dap -expected-id $_DAP_TAPID -irlen 4
+jtag newtap $_CHIPNAME dap -expected-id $_DAP_TAPID -irlen 4 -ircapture 0x01 -irmask 0x0f
 
 set _TARGETNAME0 $_CHIPNAME.cpu0
 set _TARGETNAME1 $_CHIPNAME.cpu1
 set _TARGETNAME2 $_CHIPNAME.cpu2
 set _TARGETNAME3 $_CHIPNAME.cpu3
 
-target create $_TARGETNAME0 cortex_a -chain-position $_CHIPNAME.dap -coreid 0 -dbgbase 0x3fe10000
-target create $_TARGETNAME1 cortex_a -chain-position $_CHIPNAME.dap -coreid 1 -dbgbase 0x3fe12000
-target create $_TARGETNAME2 cortex_a -chain-position $_CHIPNAME.dap -coreid 2 -dbgbase 0x3fe14000
-target create $_TARGETNAME3 cortex_a -chain-position $_CHIPNAME.dap -coreid 3 -dbgbase 0x3fe16000
+target create $_TARGETNAME0 cortex_a -chain-position $_CHIPNAME.dap -coreid 0 -dbgbase 0x80010000
+target create $_TARGETNAME1 cortex_a -chain-position $_CHIPNAME.dap -coreid 1 -dbgbase 0x80012000
+target create $_TARGETNAME2 cortex_a -chain-position $_CHIPNAME.dap -coreid 2 -dbgbase 0x80014000
+target create $_TARGETNAME3 cortex_a -chain-position $_CHIPNAME.dap -coreid 3 -dbgbase 0x80016000
 target smp $_TARGETNAME0 $_TARGETNAME1 $_TARGETNAME2 $_TARGETNAME3
 
-#$_TARGETNAME0 configure -event gdb-attach {
-	#cortex_a dbginit
-#}
-#$_TARGETNAME1 configure -event gdb-attach {
-	#cortex_a dbginit
-#}
-#$_TARGETNAME2 configure -event gdb-attach {
-	#cortex_a dbginit
-#}
-#$_TARGETNAME3 configure -event gdb-attach {
-	#cortex_a dbginit
-#}
+$_TARGETNAME0 configure -event gdb-attach {
+	cortex_a dbginit
+}
+$_TARGETNAME1 configure -event gdb-attach {
+	cortex_a dbginit
+}
+$_TARGETNAME2 configure -event gdb-attach {
+	cortex_a dbginit
+}
+$_TARGETNAME3 configure -event gdb-attach {
+	cortex_a dbginit
+}


### PR DESCRIPTION
I updated the README files with instructions on how to use the FT2232H Mini-Module. Also modified the OpenOCD configuration script for RPi2 with the correct addresses, and it appears to work correctly for me now.